### PR TITLE
feat: add author attribution footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,7 @@ Make your updates, then:
 6. Serve the contents of the /dist folder with `bun run serve dist`
 	> Navigate to the localhost URL detailed in your terminal
 
+---
+
+Made by [Destiner](https://destiner.io).
+

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -96,7 +96,9 @@ export default [
       'vue/no-empty-component-block': 'error',
       'vue/no-multiple-objects-in-class': 'error',
       'vue/no-required-prop-with-default': 'error',
-      'vue/no-template-target-blank': 'error',
+      // allowReferrer keeps the Referer header on outbound links so referral
+      // traffic stays attributable in analytics
+      'vue/no-template-target-blank': ['error', { allowReferrer: true }],
       'vue/no-undef-components': 'error',
       'vue/no-undef-properties': 'error',
       'vue/no-unused-emit-declarations': 'error',

--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
       name="description"
       content="An interactive reference of the Ethereum node API."
     />
+    <meta
+      name="author"
+      content="Timur Badretdinov"
+    />
 
     <!-- Encoding -->
     <meta charset="utf-8" />

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,14 @@
 <template>
   <EthHeader />
   <RouterView />
+  <EthFooter />
 </template>
 
 <script setup lang="ts">
 import '@fontsource-variable/inter';
 import { RouterView } from 'vue-router';
 
+import EthFooter from '@/components/_app/footer/EthFooter.vue';
 import EthHeader from '@/components/_app/header/EthHeader.vue';
 </script>
 
@@ -84,6 +86,7 @@ import EthHeader from '@/components/_app/header/EthHeader.vue';
 
 body {
   --header-height: 58px;
+  --footer-height: 40px;
 
   margin: 0;
   background: var(--color-bg-primary);

--- a/src/components/_app/footer/EthFooter.vue
+++ b/src/components/_app/footer/EthFooter.vue
@@ -1,0 +1,32 @@
+<template>
+  <footer>
+    <a
+      href="https://destiner.io"
+      target="_blank"
+      rel="noopener"
+    >
+      Made by Destiner
+    </a>
+  </footer>
+</template>
+
+<style scoped>
+footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--footer-height);
+  border-top: 1px solid var(--color-border-primary);
+}
+
+a {
+  opacity: 0.6;
+  color: inherit;
+  font-size: var(--font-size-small);
+  text-decoration: inherit;
+}
+
+a:hover {
+  opacity: 1;
+}
+</style>

--- a/src/pages/ExecutionApi.vue
+++ b/src/pages/ExecutionApi.vue
@@ -152,7 +152,7 @@ main {
   display: flex;
   gap: var(--spacing-normal);
   flex-direction: column;
-  min-height: calc(100vh - 64px);
+  min-height: calc(100vh - 64px - var(--footer-height));
 }
 
 @media (width >= 768px) {


### PR DESCRIPTION
Adds a site-wide footer with a "Made by Destiner" link to [destiner.io](https://destiner.io), an `author` meta tag, and a README attribution line.

The reference page reserves viewport height explicitly, so its `min-height` now subtracts the new `--footer-height` to keep the layout fitting the viewport.

Also sets `allowReferrer` on `vue/no-template-target-blank` so the `Referer` header is preserved on outbound links — without it the rule forces `noreferrer`, which would make referral traffic invisible in analytics.