### PR TITLE
fix: use git+https for the repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/Destiner/ethereum-json-rpc.git"
+    "url": "git+https://github.com/Destiner/ethereum-json-rpc.git"
   },
   "scripts": {
     "generate:providers": "bun src/scripts/fetchProviders.ts",


### PR DESCRIPTION
GitHub disabled the unauthenticated `git://` protocol in 2022, so the existing repository URL no longer resolves.